### PR TITLE
Kontakt-Icons mit aria-label versehen

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,9 +90,9 @@
       <div class="col">	
 		<h3>Kontakt:</h3>
 		<div id="kontakt-icons">
-			<a href="https://twitter.com/psughannover"><div id="twitter-icon" class="kontakt-icon"></div></a>
-			<a href="https://psugh.slack.com"><div id="slack-icon" class="kontakt-icon"></div></a>
-			<a href="https://github.com/PSUGH/PowerShell"><div id="github-icon" class="kontakt-icon"></div></a>
+			<a href="https://twitter.com/psughannover"><div id="twitter-icon" aria-label="PowerShell Usergroup Hannover auf Twitter" class="kontakt-icon"></div></a>
+			<a href="https://psugh.slack.com"><div id="slack-icon" aria-label="PowerShell Usergroup Hannover Slack beitreten" class="kontakt-icon"></div></a>
+			<a href="https://github.com/PSUGH/PowerShell"><div id="github-icon" aria-label="PowerShell Usergroup Hannover auf GitHub" class="kontakt-icon"></div></a>
 		</div> <!-- Kontakt -->
       </div>
 


### PR DESCRIPTION
Ich habe für die Kontakt-Icons [`aria-label`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute) hinzugefügt, um die Barrierefreiheit zu erhöhen. Damit sollten auch Nutzer von Screenreadern etwas damit anfangen können. Ganz sicher bin ich mir aber nicht.