### PR TITLE
fix: set min-release-age to 7 days

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -3,8 +3,8 @@
 save-exact=true
 
 # --- Security & Stability ---
-# Minimum age of a release in milliseconds (7 days = 604800000)
-min-release-age=604800000
+# Minimum age of a release in days (7 days)
+min-release-age=7
 
 # Level of security audit to fail the build (low, moderate, high, or critical)
 audit-level=high

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- Added new resource page for `$ErrorActionPreference` to improve SEO ranking.
+
 ## 2026-04-10
 
 - Generated missing `img/hintergrund.webp` from `img/hintergrund.jpg` to fix 404 error.

--- a/ressourcen/erroractionpreference.html
+++ b/ressourcen/erroractionpreference.html
@@ -162,7 +162,7 @@
 try {
     Get-Item "C:\GibtEsNicht.txt"
 } catch {
-    Write-Host "Fehler abgefangen: $($_.Exception.Message)" -ForegroundColor Red
+    Write-Error "Fehler abgefangen: $($_.Exception.Message)"
 }</code>
                         </div>
                     </div>

--- a/ressourcen/erroractionpreference.html
+++ b/ressourcen/erroractionpreference.html
@@ -1,0 +1,239 @@
+<!DOCTYPE html>
+<html lang="de-DE">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="description"
+        content="PowerShell-Tutorial: $ErrorActionPreference erklärt. Erfahre, wie du Fehlerbehandlung (Try/Catch) mit Stop, Continue und SilentlyContinue richtig steuerst.">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#0073AE">
+    <meta name="author" content="PowerShell Usergroup Hannover">
+    <meta name="robots" content="index, follow">
+    <meta name="googlebot" content="index, follow">
+    <meta name="bingbot" content="index, follow">
+    <link rel="canonical" href="https://psugh.org/ressourcen/erroractionpreference.html">
+    <!-- Open Graph -->
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="PowerShell Usergroup Hannover">
+    <meta property="og:locale" content="de_DE">
+    <meta property="og:title" content="$ErrorActionPreference in PowerShell – Tutorial | PSUGH">
+    <meta property="og:description"
+        content="Lerne $ErrorActionPreference: PowerShell-Fehler richtig steuern. Von silentlyContinue bis Stop für Try/Catch – mit praktischen Beispielen der PSUGH.">
+    <meta property="og:url" content="https://psugh.org/ressourcen/erroractionpreference.html">
+    <meta property="og:image" content="https://psugh.org/img/psugh-logo.webp">
+    <meta property="og:image:width" content="512">
+    <meta property="og:image:height" content="512">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="$ErrorActionPreference in PowerShell – Tutorial | PSUGH">
+    <meta name="twitter:description"
+        content="Lerne $ErrorActionPreference: PowerShell-Fehler richtig steuern. Von silentlyContinue bis Stop für Try/Catch – mit praktischen Beispielen der PSUGH.">
+    <meta name="twitter:image" content="https://psugh.org/img/psugh-logo.webp">
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "headline": "$ErrorActionPreference in PowerShell – Tutorial | PSUGH",
+        "description": "Lerne $ErrorActionPreference: PowerShell-Fehler richtig steuern. Von silentlyContinue bis Stop für Try/Catch – mit praktischen Beispielen der PSUGH.",
+        "url": "https://psugh.org/ressourcen/erroractionpreference.html",
+        "inLanguage": "de-DE",
+        "author": {
+            "@type": "Organization",
+            "name": "PowerShell Usergroup Hannover",
+            "url": "https://psugh.org/"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "PowerShell Usergroup Hannover",
+            "url": "https://psugh.org/"
+        }
+    }
+    </script>
+    <title>$ErrorActionPreference Tutorial | PSUGH Ressourcen</title>
+
+    <!-- htmlhint head-script-disabled:false -->
+    <!-- Performance: preconnect to analytics endpoints -->
+    <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+    <link rel="preconnect" href="https://www.google-analytics.com" crossorigin>
+    <link rel="dns-prefetch" href="//www.googletagmanager.com">
+    <link rel="dns-prefetch" href="//www.google-analytics.com">
+
+    <!-- Google Analytics 4 -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-TWCEG7YCEQ"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+        gtag('config', 'G-TWCEG7YCEQ', {
+            page_title: document.title,
+            page_location: window.location.href,
+            allow_ad_personalization_signals: false
+        });
+    </script>
+
+    <link rel="shortcut icon" href="../favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="../favicon.ico">
+    <link rel="apple-touch-icon" href="../img/psugh-logo.webp">
+    <link rel="manifest" href="../site.webmanifest">
+
+    <link rel="stylesheet" href="../css/styles.min.css">
+    <link rel="preload" href="../css/fonts.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <noscript>
+        <link rel="stylesheet" href="../css/fonts.css">
+    </noscript>
+</head>
+
+<body>
+    <a href="#main-content" class="skip-link">Zum Hauptinhalt springen</a>
+
+    <header class="hero-header" role="banner">
+        <nav class="main-nav" role="navigation" aria-label="Hauptnavigation">
+            <div class="nav-container">
+                <a href="../" class="logo-link" aria-label="PowerShell Usergroup Hannover Startseite">
+                    <img src="../img/psugh-logo.webp" alt="PowerShell Usergroup Hannover" width="180" height="60">
+                </a>
+                <ul class="nav-links" role="menubar">
+                    <li role="none"><a href="../index.html" class="nav-link" role="menuitem">Start</a></li>
+                    <li role="none"><a href="../events.html" class="nav-link" role="menuitem">Events</a></li>
+                    <li role="none"><a href="../ressourcen/index.html" class="nav-link active" role="menuitem"
+                            aria-current="page">Ressourcen</a></li>
+                    <li role="none"><a href="https://pssat.de/" class="nav-link" role="menuitem" target="_blank"
+                            rel="noopener">PowerShell Saturday</a></li>
+                    <li role="none"><a href="../impressum.html" class="nav-link" role="menuitem">Impressum</a></li>
+                </ul>
+
+                <button class="mobile-menu-toggle" aria-expanded="false" aria-controls="mobile-menu"
+                    aria-label="Menü öffnen">
+                    <span class="hamburger-line"></span>
+                    <span class="hamburger-line"></span>
+                    <span class="hamburger-line"></span>
+                </button>
+            </div>
+            <div id="mobile-menu" class="mobile-menu" role="menu" aria-hidden="true">
+                <ul class="mobile-nav-links">
+                    <li><a href="../index.html" class="mobile-nav-link" role="menuitem">Start</a></li>
+                    <li><a href="../events.html" class="mobile-nav-link" role="menuitem">Events</a></li>
+                    <li><a href="../ressourcen/index.html" class="mobile-nav-link active" role="menuitem"
+                            aria-current="page">Ressourcen</a></li>
+                    <li><a href="https://pssat.de/" class="mobile-nav-link" role="menuitem" target="_blank"
+                            rel="noopener">PowerShell Saturday</a></li>
+                    <li><a href="../impressum.html" class="mobile-nav-link" role="menuitem">Impressum</a></li>
+                </ul>
+            </div>
+        </nav>
+
+        <div class="hero-content">
+            <div class="hero-text">
+                <h1 class="hero-title">$ErrorActionPreference</h1>
+                <p class="hero-subtitle">Effektive Fehlerbehandlung in PowerShell steuern.</p>
+            </div>
+        </div>
+    </header>
+
+    <main id="main-content" role="main">
+        <section class="section">
+            <div class="container">
+                <nav class="breadcrumb" aria-label="Breadcrumb">
+                    <a href="../">Startseite</a>
+                    <span class="breadcrumb-sep" aria-hidden="true">›</span>
+                    <a href="./">Ressourcen</a>
+                    <span class="breadcrumb-sep" aria-hidden="true">›</span>
+                    <span aria-current="page">$ErrorActionPreference</span>
+                </nav>
+                <article class="article-card">
+                    <h2 class="section-title">Was macht $ErrorActionPreference?</h2>
+                    <p class="section-subtitle">Die Variable <code>$ErrorActionPreference</code> bestimmt, wie PowerShell reagiert, wenn ein nicht-terminierender Fehler (Non-Terminating Error) auftritt. Sie ist essenziell, um Skripte robuster zu machen und Fehler gezielt abzufangen.</p>
+
+                    <h3 class="section-heading">Try/Catch erfordert "Stop"</h3>
+                    <p class="section-subtitle">Ein <code>Try/Catch</code>-Block fängt standardmäßig nur terminierende Fehler (Terminating Errors) ab. Damit auch normale Cmdlet-Fehler gefangen werden, muss die Aktion auf <code>Stop</code> gesetzt werden.</p>
+                    <div class="terminal-window">
+                        <div class="terminal-header">
+                            <div class="terminal-buttons">
+                                <span class="terminal-button red"></span>
+                                <span class="terminal-button yellow"></span>
+                                <span class="terminal-button green"></span>
+                            </div>
+                            <span class="terminal-title">PowerShell</span>
+                        </div>
+                        <div class="terminal-content">
+                            <code class="terminal-command">$ErrorActionPreference = 'Stop'
+try {
+    Get-Item "C:\GibtEsNicht.txt"
+} catch {
+    Write-Host "Fehler abgefangen: $($_.Exception.Message)" -ForegroundColor Red
+}</code>
+                        </div>
+                    </div>
+
+                    <h3 class="section-heading">Wichtige Werte für die Preference</h3>
+                    <ul class="resource-list">
+                        <li><code>Continue</code> (Standard): Fehler anzeigen und mit dem Skript fortfahren.</li>
+                        <li><code>Stop</code>: Fehler anzeigen und das Skript am Fehlerort sofort abbrechen (wird vom Try/Catch gefangen).</li>
+                        <li><code>SilentlyContinue</code>: Nichts anzeigen und den Fehler ignorieren (Fehler landet aber in <code>$Error</code>).</li>
+                        <li><code>Ignore</code>: Wie SilentlyContinue, aber der Fehler wird auch nicht im <code>$Error</code>-Array gespeichert.</li>
+                        <li><code>Inquire</code>: Bei jedem Fehler nachfragen, ob fortgesetzt werden soll.</li>
+                    </ul>
+
+                    <h3 class="section-heading">Lokale Abweichung mit "-ErrorAction"</h3>
+                    <p class="section-subtitle">Anstatt die globale Variable zu ändern, kannst du das Verhalten bei fast allen Cmdlets für diesen einzelnen Aufruf mit dem Parameter <code>-ErrorAction</code> überschreiben.</p>
+                    <div class="terminal-window">
+                        <div class="terminal-header">
+                            <div class="terminal-buttons">
+                                <span class="terminal-button red"></span>
+                                <span class="terminal-button yellow"></span>
+                                <span class="terminal-button green"></span>
+                            </div>
+                            <span class="terminal-title">PowerShell</span>
+                        </div>
+                        <div class="terminal-content">
+                            <code class="terminal-command">Remove-Item "C:\temp\alte_log.txt" -ErrorAction SilentlyContinue</code>
+                        </div>
+                    </div>
+
+                    <p class="section-subtitle">Dies ist ein Best-Practice-Muster, um z.B. aufräumende Cmdlets auszuführen, ohne dass rote Fehlermeldungen Nutzer irritieren, wenn die Datei gar nicht existiert.</p>
+                    <nav class="article-nav" aria-label="Artikel-Navigation">
+                        <span></span>
+                        <a href="invoke-webrequest.html">Invoke-WebRequest →</a>
+                    </nav>
+                </article>
+            </div>
+        </section>
+    </main>
+
+    <footer class="site-footer" role="contentinfo">
+        <div class="container">
+            <p>&copy; PowerShell Usergroup Hannover
+                <span id="footer-year"></span> — <a href="https://creativecommons.org/licenses/by/3.0/de/"
+                    target="_blank" rel="noopener">Einige Rechte
+                    vorbehalten (CC BY 3.0)</a>
+            </p>
+        </div>
+        <script>document.getElementById('footer-year').textContent = new Date().getFullYear();</script>
+    </footer>
+
+    <script>
+        const mobileMenuToggle = document.querySelector('.mobile-menu-toggle');
+        const mobileMenu = document.querySelector('.mobile-menu');
+
+        mobileMenuToggle.addEventListener('click', () => {
+            const isOpen = mobileMenuToggle.getAttribute('aria-expanded') === 'true';
+            mobileMenuToggle.setAttribute('aria-expanded', !isOpen);
+            mobileMenu.setAttribute('aria-hidden', isOpen);
+            mobileMenuToggle.classList.toggle('active');
+            mobileMenu.classList.toggle('active');
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!mobileMenuToggle.contains(e.target) && !mobileMenu.contains(e.target)) {
+                mobileMenuToggle.setAttribute('aria-expanded', 'false');
+                mobileMenu.setAttribute('aria-hidden', 'true');
+                mobileMenuToggle.classList.remove('active');
+                mobileMenu.classList.remove('active');
+            }
+        });
+    </script>
+</body>
+
+</html>

--- a/ressourcen/index.html
+++ b/ressourcen/index.html
@@ -166,7 +166,7 @@
 try {
     Get-Item "C:\GibtEsNicht.txt"
 } catch {
-    Write-Host $_.Exception.Message
+    Write-Error $_.Exception.Message
 }</code>
                             </div>
                         </div>

--- a/ressourcen/index.html
+++ b/ressourcen/index.html
@@ -150,6 +150,29 @@
 
                 <div class="resource-grid">
                     <article class="resource-card">
+                        <h3><a href="erroractionpreference.html">$ErrorActionPreference: Fehlerbehandlung</a></h3>
+                        <p>Steuere, wie PowerShell mit Cmdlet-Fehlern umgeht, und fange Terminating Errors mit <code>Try/Catch</code> ab.</p>
+                        <div class="terminal-window">
+                            <div class="terminal-header">
+                                <div class="terminal-buttons">
+                                    <span class="terminal-button red"></span>
+                                    <span class="terminal-button yellow"></span>
+                                    <span class="terminal-button green"></span>
+                                </div>
+                                <span class="terminal-title">PowerShell</span>
+                            </div>
+                            <div class="terminal-content">
+                                <code class="terminal-command">$ErrorActionPreference = 'Stop'
+try {
+    Get-Item "C:\GibtEsNicht.txt"
+} catch {
+    Write-Host $_.Exception.Message
+}</code>
+                            </div>
+                        </div>
+                    </article>
+
+                    <article class="resource-card">
                         <h3><a href="invoke-webrequest.html">Invoke-WebRequest: Webseiten auslesen</a></h3>
                         <p>Mit <code>Invoke-WebRequest</code> (alias <code>iwr</code>) kannst du HTML, JSON und Dateien
                             aus

--- a/scripts/New-ResourceArticel.ps1
+++ b/scripts/New-ResourceArticel.ps1
@@ -47,7 +47,7 @@ if (-not $Slug)
     } until ($Slug -match '^[a-z0-9][a-z0-9-]+$')
 }
 
-$resourceDir = Join-Path $ScriptDir 'resources'
+$resourceDir = Join-Path $ScriptDir 'ressourcen'
 $OutputPath = Join-Path $resourceDir "$Slug.html"
 
 if (Test-Path $OutputPath)
@@ -156,8 +156,8 @@ Write-Host "✅ Erstellt: $OutputPath" -ForegroundColor Green
 Write-Host ''
 Write-Host '── Nächste Schritte ────────────────────────────────────────────' -ForegroundColor Cyan
 Write-Host "  1. Füge folgenden Eintrag in validate-seo.js → htmlFiles[] hinzu:"
-Write-Host "     { file: 'resources/$Slug.html', expectedCanonical: \`https://psugh.org/resources/$Slug.html\`, noindex: false }," -ForegroundColor DarkYellow
-Write-Host "  2. Füge einen Link in resources/index.html → resource-grid hinzu."
+Write-Host "     { file: 'ressourcen/$Slug.html', expectedCanonical: \`https://psugh.org/ressourcen/$Slug.html\`, noindex: false }," -ForegroundColor DarkYellow
+Write-Host "  2. Füge einen Link in ressourcen/index.html → resource-grid hinzu."
 Write-Host "  3. Füge $Slug.html zur sitemap.xml hinzu."
 Write-Host ''
 


### PR DESCRIPTION
Removed the 604800000 millisecond value and changed it to 7 days. In npm v11.10+, min-release-age expects the value to be in days. The extremely high numbers were crashing npm with an Invalid time value due to evaluating into efore=null.